### PR TITLE
Prevent scrolling when dragging on the toolbars

### DIFF
--- a/css/kidpix.css
+++ b/css/kidpix.css
@@ -19,6 +19,11 @@ body {
     width: 100%;
 }
 
+#toolbar,
+#subtoolbars {
+    touch-action: none;
+}
+
 #hcontainer {
     /*
   border: solid;


### PR DESCRIPTION
This prevents scrolling the entire app when accidentally dragging on the toolbars.